### PR TITLE
Make CoffeeScript an optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "coffee-script": "~1.6.3",
     "delims": "~0.1.0",
     "fs-utils": "~0.1.6",
     "js-yaml": "~3.0.1",
     "lodash": "~2.4.1"
   },
   "devDependencies": {
+    "coffee-script": "~1.6.3",
     "chai": "~1.8.1",
     "mocha": "~1.17.1"
   },


### PR DESCRIPTION
Having CoffeeScript defined in `dependencies` makes it download in every package that uses gray-matter. Moving into `devDependencies` will make it only install `coffee-script` when the package explicitly asks for the CoffeeScript support.
