### PR TITLE
strip a single newline after end delimiter

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,14 @@ function matter(str, options) {
     }
   }
 
-  res.content = str.substr(end + b.length);
+  // grab the content from the string, stripping
+  // an optional new line after the second delim
+  var con = str.substr(end + b.length);
+  if (con.charAt(0) === '\n') {
+    con = con.substr(1);
+  }
+
+  res.content = con;
   return res;
 }
 

--- a/test/matter.js
+++ b/test/matter.js
@@ -42,7 +42,7 @@ describe('Read from strings:', function () {
     var fixture = '---\nabc: xyz\nversion: 2\n---\n\n<span class="alert alert-info">This is an alert</span>\n';
     var actual = matter(fixture);
     actual.should.have.property('data', {abc: 'xyz', version: 2});
-    actual.should.have.property('content', '\n\n<span class="alert alert-info">This is an alert</span>\n');
+    actual.should.have.property('content', '\n<span class="alert alert-info">This is an alert</span>\n');
     actual.should.have.property('orig');
   });
 
@@ -50,7 +50,7 @@ describe('Read from strings:', function () {
     var fixture = '~~~\nabc: xyz\nversion: 2\n~~~\n\n<span class="alert alert-info">This is an alert</span>\n';
     var actual = matter(fixture, {delims: '~~~'});
     actual.should.have.property('data', {abc: 'xyz', version: 2});
-    actual.should.have.property('content', '\n\n<span class="alert alert-info">This is an alert</span>\n');
+    actual.should.have.property('content', '\n<span class="alert alert-info">This is an alert</span>\n');
     actual.should.have.property('orig');
   });
 
@@ -58,7 +58,7 @@ describe('Read from strings:', function () {
     var fixture = '~~~\nabc: xyz\nversion: 2\n~~~\n\n<span class="alert alert-info">This is an alert</span>\n';
     var actual = matter(fixture, {delims: ['~~~']});
     actual.should.have.property('data', {abc: 'xyz', version: 2});
-    actual.should.have.property('content', '\n\n<span class="alert alert-info">This is an alert</span>\n');
+    actual.should.have.property('content', '\n<span class="alert alert-info">This is an alert</span>\n');
     actual.should.have.property('orig');
   });
 
@@ -66,7 +66,7 @@ describe('Read from strings:', function () {
     var fixture = '---\nname: "troublesome --- value"\n---\nhere is some content\n';
     var actual = matter(fixture);
     actual.should.have.property('data', {name: 'troublesome --- value'});
-    actual.should.have.property('content', '\nhere is some content\n');
+    actual.should.have.property('content', 'here is some content\n');
     actual.should.have.property('orig', '---\nname: "troublesome --- value"\n---\nhere is some content\n');
   });
 

--- a/test/matter.read.js
+++ b/test/matter.read.js
@@ -17,7 +17,7 @@ describe('Read from file system:', function () {
 
     actual.should.have.property('path');
     actual.should.have.property('data', {title: 'Basic'});
-    actual.should.have.property('content', '\nthis is content.');
+    actual.should.have.property('content', 'this is content.');
   });
 
   it('should parse complex YAML front matter.', function () {

--- a/test/parse-yaml.js
+++ b/test/parse-yaml.js
@@ -40,7 +40,7 @@ describe('parse YAML:', function () {
     var fixture = '---\nabc: xyz\nversion: 2\n---\n\n<span class="alert alert-info">This is an alert</span>\n';
     var actual = matter(fixture, {safeLoad: true});
     actual.should.have.property('data', {abc: 'xyz', version: 2});
-    actual.should.have.property('content', '\n\n<span class="alert alert-info">This is an alert</span>\n');
+    actual.should.have.property('content', '\n<span class="alert alert-info">This is an alert</span>\n');
     actual.should.have.property('orig');
   });
 });


### PR DESCRIPTION
Implements the stripping behavior talked about in: https://github.com/jonschlinkert/gray-matter/issues/11, which I realized makes it more symmetrical with `.stringify` too.

(Although `stringify` adds an extra newline, which maybe we should remove for perfectly symmetry.)