### PR TITLE
experimental sections support

### DIFF
--- a/test/fixtures/sections.md
+++ b/test/fixtures/sections.md
@@ -1,0 +1,30 @@
+---json
+{
+  "title": "JSON",
+  "description": "Front Matter"
+}
+---
+
+# This page has JSON front matter!
+
+----
+title: one
+----
+
+Section one.
+
+----
+title: two
+----
+
+Section two, part 1.
+
+---
+
+Section two, part 2.
+
+----
+title: three
+----
+
+Section three.

--- a/test/sections.js
+++ b/test/sections.js
@@ -1,0 +1,23 @@
+/*!
+ * gray-matter <https://github.com/jonschlinkert/gray-matter>
+ *
+ * Copyright (c) 2014-2017, Jon Schlinkert.
+ * Released under the MIT License.
+ */
+
+'use strict';
+
+var path = require('path');
+var assert = require('assert');
+var matter = require('..');
+var fixture = path.join.bind(path, __dirname, 'fixtures');
+
+describe('.sections', function() {
+  it.only('should extract sections from a file', function() {
+    var file = matter.read(fixture('sections.md'), {sections: true});
+    console.log(file)
+    // assert(file.hasOwnProperty('path'));
+    // assert(file.hasOwnProperty('data', {title: 'Basic'}));
+    // assert.equal(file.content, 'this is content.');
+  });
+});


### PR DESCRIPTION
This PR adds experimental support for "section matter", this is for discussion only at this point. I'm not even sure if we should do this. There are some questions that need to answered before this can really work in a practical way. 

**What is "section matter"?**

Section matter is like front-matter, but can be used to create multiple "front-matter" delimited sections in the same document. There have been a number of requests for this over the past few years, the most common use case I've seen is for creating slide decks, but I'm sure there are other uses (and I'd love to hear about them!).

**What does it look like?**

This is up in the air, but in principle it works something like this (although `---` [won't be good enough](#delimiters), this is just for the sake of discussion):

```html
---
title: This is front matter
---

This is text before the first "section".

---
title: This is section matter
---

This is text for the first section.

---
title: This is section matter
---

This is text for the second section.

```

Which would yield an object like this:


```js
{
  data: { title: 'This is front matter' },
  content: 'This is text before the first "section".',

  // sections would _EITHER_ be formatted as an array
  sections: [
    {
      data: { title: 'This is section matter'},
      content: 'This is text for the first section.'
    },
    {
      data: { title: 'This is section matter'},
      content: 'This is text for the second section.'
    }
  ],

  // _OR_ as an object, in which case we would need to "label" the sections,
  // If we do this, the label would probably be immediately after the first delimiter
  sections: {
    foo: {
      data: { title: 'This is section matter'},
      content: 'This is text for the first section.'
    },
    bar: {
      data: { title: 'This is section matter'},
      content: 'This is text for the second section.'
    }
  }
}
```

## Assumptions

- `options.sections` must be defined as true (example: `matter(string, { sections: true })`) 
- `file.sections` will be an array or object of "section" objects. Each section object will have a `data` and `content` property.
- `file.contents` will contain the text preceding the first section


## Delimiters

I'd love some feedback on this.

Delimiters must be more than just `---`, since that would easily conflict with normal markdown horizontal rules. 

If we need to keep it extremely simple, I propose that we at least use `----` (4 instead of 3), but ideally we can use some kind of marker or label after the first delimiter, maybe even the second one as well.

**Ideas**

1. Both delimiters marked

```
---section
title: this is a section
---end

This is a section

```

2. Opening delimiter marked

```
---section
title: this is a section
---

This is a section

```

3. Both delimiters marked, first delimited labeled (optional?)

```
---section: Foo
title: this is a section
---end

This is a section

```

4. Opening delimiter marked and labeled

```
---section: Foo
title: this is a section
---

This is a section

```

5. Opening delimiter marked with colon only

```
---:
title: this is a section
---

This is a section

```

6. Opening delimiter marked with colon and label

```
---: Foo
title: this is a section
---

This is a section

```

7. Opening delimiter with label only

```
---Foo
title: this is a section
---

This is a section

```

Or, I could easily support all of the above formats with very little code, but we at least need some kind of marker and/or label to make sure we avoid false positives from collisions with markdown horizontal rules. 
