### PR TITLE
Lock down coffee-script to remove error being thrown in 1.12.8

### DIFF
--- a/examples/coffee.js
+++ b/examples/coffee.js
@@ -1,6 +1,6 @@
 var path = require('path');
 var matter = require('..');
-var coffee = require('coffeescript);
+var coffee = require('coffeescript');
 var magenta = require('ansi-magenta');
 
 var fixture = path.join.bind(path, __dirname, 'fixtures');

--- a/examples/coffee.js
+++ b/examples/coffee.js
@@ -1,6 +1,6 @@
 var path = require('path');
 var matter = require('..');
-var coffee = require('coffee-script');
+var coffee = require('coffeescript);
 var magenta = require('ansi-magenta');
 
 var fixture = path.join.bind(path, __dirname, 'fixtures');

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "ansi-magenta": "^0.1.1",
     "benchmarked": "^2.0.0",
-    "coffee-script": "^1.12.7",
+    "coffeescript": "1.12.7",
     "delimiter-regex": "^2.0.0",
     "front-matter": "^2.2.0",
     "gulp-format-md": "^1.0.0",

--- a/test/parse-coffee.js
+++ b/test/parse-coffee.js
@@ -12,7 +12,7 @@ var assert = require('assert');
 var extend = require('extend-shallow');
 var matter = require('../');
 var fixture = path.join.bind(path, __dirname, 'fixtures');
-var coffee = require('coffeescript);
+var coffee = require('coffeescript');
 var defaults = {
   engines: {
     coffee: {

--- a/test/parse-coffee.js
+++ b/test/parse-coffee.js
@@ -12,7 +12,7 @@ var assert = require('assert');
 var extend = require('extend-shallow');
 var matter = require('../');
 var fixture = path.join.bind(path, __dirname, 'fixtures');
-var coffee = require('coffee-script');
+var coffee = require('coffeescript);
 var defaults = {
   engines: {
     coffee: {

--- a/test/parse-cson.js
+++ b/test/parse-cson.js
@@ -11,7 +11,7 @@ var path = require('path');
 var assert = require('assert');
 var matter = require('..');
 var extend = require('extend-shallow');
-var coffee = require('coffeescript);
+var coffee = require('coffeescript');
 var fixture = path.join.bind(path, __dirname, 'fixtures');
 var defaults = {
   engines: {

--- a/test/parse-cson.js
+++ b/test/parse-cson.js
@@ -11,7 +11,7 @@ var path = require('path');
 var assert = require('assert');
 var matter = require('..');
 var extend = require('extend-shallow');
-var coffee = require('coffee-script');
+var coffee = require('coffeescript);
 var fixture = path.join.bind(path, __dirname, 'fixtures');
 var defaults = {
   engines: {


### PR DESCRIPTION
coffee-script 1.12.8 is causing an error. To suppress the error we should lock down coffee-script to 1.12.7 until the error is resolved.