### PR TITLE
Rename coffee-script to coffeescript

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,7 @@
     "ansi-gray": "^0.1.1",
     "ansi-magenta": "^0.1.1",
     "benchmarked": "^0.2.5",
-    "coffee-script": "^1.12.6",
+    "coffeescript": "^1.12.7",
     "delimiter-regex": "^2.0.0",
     "extend-shallow": "^2.0.1",
     "for-own": "^0.1.4",
@@ -57,7 +57,7 @@
   "keywords": [
     "assemble",
     "coffee",
-    "coffee-script",
+    "coffeescript",
     "data",
     "docs",
     "documentation",

--- a/examples/coffee.js
+++ b/examples/coffee.js
@@ -1,6 +1,6 @@
 var path = require('path');
 var matter = require('..');
-var coffee = require('coffee-script');
+var coffee = require('coffeescript');
 var magenta = require('ansi-magenta');
 
 var fixture = path.join.bind(path, __dirname, 'fixtures');

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "ansi-magenta": "^0.1.1",
     "benchmarked": "^2.0.0",
-    "coffee-script": "^1.12.7",
+    "coffeescript": "^1.12.7",
     "delimiter-regex": "^2.0.0",
     "front-matter": "^2.2.0",
     "gulp-format-md": "^1.0.0",
@@ -58,7 +58,7 @@
   "keywords": [
     "assemble",
     "coffee",
-    "coffee-script",
+    "coffeescript",
     "data",
     "docs",
     "documentation",
@@ -111,7 +111,7 @@
       ]
     },
     "reflinks": [
-      "coffe-script",
+      "coffescript",
       "generate",
       "js-yaml",
       "toml",

--- a/test/fixtures/lang-coffee.md
+++ b/test/fixtures/lang-coffee.md
@@ -4,7 +4,7 @@ description: '''
   Front matter
   '''
 categories: '''
-  front matter coffee coffee-script
+  front matter coffee coffeescript
   '''
 ---
 

--- a/test/parse-coffee.js
+++ b/test/parse-coffee.js
@@ -12,7 +12,7 @@ var assert = require('assert');
 var extend = require('extend-shallow');
 var matter = require('../');
 var fixture = path.join.bind(path, __dirname, 'fixtures');
-var coffee = require('coffee-script');
+var coffee = require('coffeescript');
 var defaults = {
   engines: {
     coffee: {

--- a/test/parse-cson.js
+++ b/test/parse-cson.js
@@ -11,7 +11,7 @@ var path = require('path');
 var assert = require('assert');
 var matter = require('..');
 var extend = require('extend-shallow');
-var coffee = require('coffee-script');
+var coffee = require('coffeescript');
 var fixture = path.join.bind(path, __dirname, 'fixtures');
 var defaults = {
   engines: {


### PR DESCRIPTION
Since the package coffee-script was deprecated in NPM in favor of the coffeescript package