### PR TITLE
GrayMatterFile interface typo: excrept

### DIFF
--- a/gray-matter.d.ts
+++ b/gray-matter.d.ts
@@ -39,7 +39,7 @@ declare namespace matter {
   interface GrayMatterFile<I extends Input> {
     data: object
     content: string
-    excrept?: string
+    excerpt?: string
     orig: Buffer | I
     language: string
     matter: string


### PR DESCRIPTION
`GrayMatterFile` interface property `excrept` should be `excerpt`?