### PR TITLE
[typescript] use index type for GrayMatterFile.data

### DIFF
--- a/gray-matter.d.ts
+++ b/gray-matter.d.ts
@@ -37,7 +37,7 @@ declare namespace matter {
     delimiters?: string | [string, string]
   }
   interface GrayMatterFile<I extends Input> {
-    data: object
+    data: { [key: string]: any }
     content: string
     excerpt?: string
     orig: Buffer | I


### PR DESCRIPTION
`object` type doesn't allow to access its fields:

![image](https://user-images.githubusercontent.com/2317341/39315142-3db3cf40-4976-11e8-9161-039ecb0e37a2.png)

Instead it'd better to use an [index type](https://www.typescriptlang.org/docs/handbook/advanced-types.html). This way any field of `data` is resolved as `any`:

![image](https://user-images.githubusercontent.com/2317341/39315324-b957f824-4976-11e8-885c-5665d48594c4.png)

