### PR TITLE
[typescript] fix GrayMatterOption.engines type

### DIFF
--- a/gray-matter.d.ts
+++ b/gray-matter.d.ts
@@ -30,8 +30,8 @@ declare namespace matter {
     excerpt_separator?: string
     engines?: {
       [index: string]:
-        | ((string) => object)
-        | { parse: (string) => object; stringify?: (object) => string }
+        | ((input: string) => object)
+        | { parse: (input: string) => object; stringify?: (data: object) => string }
     }
     language?: string
     delimiters?: string | [string, string]


### PR DESCRIPTION
The current definition of `GrayMatterOption.engines` is not correct. `string` and `object` in this snippet are not types, but the parameter names. Their type is resolved as `any`.

```typescript
engines?: {
  [index: string]:
    | ((string) => object)
    | { parse: (string) => object; stringify?: (object) => string }
}
```

The problem is that the TypeScript requires to always put parameter names.