### PR TITLE
Arrow function breaks in IE 11

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,5 +222,5 @@ matter.language = function(str, options) {
  */
 
 matter.cache = {};
-matter.clearCache = () => (matter.cache = {});
+matter.clearCache = function() { matter.cache = {} };
 module.exports = matter;


### PR DESCRIPTION
`=>` is not supported in IE11, thus breaks the website in IE11 when it uses gray-matter library.