### PR TITLE
Fix typing issues

### DIFF
--- a/gray-matter.d.ts
+++ b/gray-matter.d.ts
@@ -30,8 +30,8 @@ declare namespace matter {
     excerpt_separator?: string
     engines?: {
       [index: string]:
-        | ((string) => object)
-        | { parse: (string) => object; stringify?: (object) => string }
+        | ((input: string) => object)
+        | { parse: (input: string) => object; stringify?: (data: object) => string }
     }
     language?: string
     delimiters?: string | [string, string]


### PR DESCRIPTION
When you have types in a function declaration you should give the arguments a name. Here are some proposed names.

<img width="833" alt="screen shot 2018-09-18 at 9 31 03 am" src="https://user-images.githubusercontent.com/149178/45655860-a0289b80-bb25-11e8-909b-689fdc3997e6.png">
