### PR TITLE
Add explicit types for GrayMatterOption.engines

### DIFF
--- a/gray-matter.d.ts
+++ b/gray-matter.d.ts
@@ -30,8 +30,8 @@ declare namespace matter {
     excerpt_separator?: string
     engines?: {
       [index: string]:
-        | ((string) => object)
-        | { parse: (string) => object; stringify?: (object) => string }
+        | ((str: string) => object)
+        | { parse: (str: string) => object; stringify?: (obj: object) => string }
     }
     language?: string
     delimiters?: string | [string, string]


### PR DESCRIPTION
Right now I can see these errors:

```
ERROR in [at-loader] ../../node_modules/gray-matter/gray-matter.d.ts:33:13 
    TS7006: Parameter 'string' implicitly has an 'any' type.

ERROR in [at-loader] ../../node_modules/gray-matter/gray-matter.d.ts:34:21 
    TS7006: Parameter 'string' implicitly has an 'any' type.

ERROR in [at-loader] ../../node_modules/gray-matter/gray-matter.d.ts:34:53 
    TS7006: Parameter 'object' implicitly has an 'any' type.
```