### PR TITLE
fix(types): add missing types

### DIFF
--- a/gray-matter.d.ts
+++ b/gray-matter.d.ts
@@ -30,8 +30,8 @@ declare namespace matter {
     excerpt_separator?: string
     engines?: {
       [index: string]:
-        | ((string) => object)
-        | { parse: (string) => object; stringify?: (object) => string }
+        | ((str: string) => object)
+        | {parse: (str: string) => object; stringify?: (obj: object) => string};
     }
     language?: string
     delimiters?: string | [string, string]


### PR DESCRIPTION
tsc produced the following error in my project:

```
Parameter has a name but no type. Did you mean 'arg0: string'?
```

As far as I can tell, that's because the types specified here are actually treated as names and their types are actually implicitly `any`.