### PR TITLE
Vulnerability fixes, Buffer constructor update

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "front-matter": "^2.3.0",
     "gulp-format-md": "^1.0.0",
     "minimist": "^1.2.0",
-    "mocha": "^3.5.3",
+    "mocha": "^6.1.4",
     "toml": "^2.3.3",
     "vinyl": "^2.1.0",
     "write": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "js-yaml": "^3.11.0",
+    "js-yaml": "^3.13.1",
     "kind-of": "^6.0.2",
     "section-matter": "^1.0.0",
     "strip-bom-string": "^1.0.0"

--- a/test/vinyl-files.js
+++ b/test/vinyl-files.js
@@ -13,12 +13,12 @@ var matter = require('..');
 
 describe('vinyl files', function() {
   it('should take a vinyl file', function() {
-    var file = new File({path: 'foo', contents: new Buffer('---\none: two\n---\nbar')});
+    var file = new File({path: 'foo', contents: Buffer.from('---\none: two\n---\nbar')});
 
     var actual = matter(file);
     assert.equal(actual.path, 'foo');
     assert.deepEqual(actual.data, {one: 'two'});
     assert.deepEqual(actual.content, 'bar');
-    assert.deepEqual(actual.contents, new Buffer('---\none: two\n---\nbar'));
+    assert.deepEqual(actual.contents, Buffer.from('---\none: two\n---\nbar'));
   });
 });


### PR DESCRIPTION
This upgrades two dependencies to resolve recent security vulnerabilities:

1. [js-yaml code injection](https://www.npmjs.com/advisories/813) is resolved by upgrading from `^3.11.0` to `^3.13.1`.
1. [growl arbitrary command excution](https://www.npmjs.com/advisories/146) is resolved by upgrading mocha from `^3.5.3` to `^6.1.4`. Yes, this is 3 major versions! I've confirmed that `npm test` still passes, though, since this repo doesn't use any of the affected APIs.

I've also updated the vinyl file tests to use `Buffer.from()` instead of `new Buffer()`, which has been [deprecated](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/) (I believe in a _very_ old version of Node, maybe 6? 😬).