### PR TITLE
fix(gray-matter.d.ts): fix excerpt declaration

### DIFF
--- a/gray-matter.d.ts
+++ b/gray-matter.d.ts
@@ -26,7 +26,7 @@ declare namespace matter {
   > {
     parser?: () => void
     eval?: boolean
-    excerpt?: boolean | ((input: I, options: O) => string)
+    excerpt?: boolean | ((input: GrayMatterFile<I>, options: O) => string)
     excerpt_separator?: string
     engines?: {
       [index: string]:


### PR DESCRIPTION
There is a difference from the actual implementation in the type declaration regarding the ‘excerpt’ option.

```ts
excerpt?: boolean | ((input: I, options: O) => string) // <- wrong
excerpt?: boolean | ((input: GrayMatterFile<I>, options: O) => string) // <- correct
```