### PR TITLE
Fix the type of excerpt function

### DIFF
--- a/gray-matter.d.ts
+++ b/gray-matter.d.ts
@@ -26,7 +26,7 @@ declare namespace matter {
   > {
     parser?: () => void
     eval?: boolean
-    excerpt?: boolean | ((input: I, options: O) => string)
+    excerpt?: boolean | ((file: GrayMatterFile<I>, options: O) => void)
     excerpt_separator?: string
     engines?: {
       [index: string]:


### PR DESCRIPTION
The "excerpt" option does not expect a function that returns a string but expects a function that mutates a file object itself.
https://github.com/jonschlinkert/gray-matter#optionsexcerpt