### PR TITLE
extend stringify options to allow unknown entries

### DIFF
--- a/gray-matter.d.ts
+++ b/gray-matter.d.ts
@@ -68,7 +68,7 @@ declare namespace matter {
   export function stringify<O extends GrayMatterOption<string, O>>(
     file: string | { content: string },
     data: object,
-    options?: GrayMatterOption<string, O>
+    options?: GrayMatterOption<string, O> & Record<string, unknown>
   ): string
 
   /**


### PR DESCRIPTION
The current `GrayMatterOption` interface does not reflect the API of the lib, more specifically the `stringify` method, which [does a passthrough of all options to the underlying engine stringify method](https://github.com/jonschlinkert/gray-matter/blob/master/lib/stringify.js#L38).

Solution: change the `options` parameter of the `stringify` method to an union type between `GrayMatterOption` and `Record<string, unknown>`, thus allowing any extra entries.