### PR TITLE
Require Buffer rather than expecting a global

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,10 @@
 'use strict';
 
+// Require Buffer, rather than expecting a global,
+// so that code bundlers and other static analyzers
+// can shim for non-None environments, such as
+// web browsers.
+const Buffer = require('buffer').Buffer;
 const stripBom = require('strip-bom-string');
 const typeOf = require('kind-of');
 


### PR DESCRIPTION
This tiny PR adds `const Buffer = require('buffer').Buffer;` to the top of `lib/util.js`, so that `util.js` can call `Buffer.from` without relying on `Buffer` being a global. This allows code bundlers and other static analyzers to detect the use of Buffer and shim it (such as with [npm:buffer](https://www.npmjs.com/package/buffer)) if it is not part of the target environment, such as when bundling for web browsers.

I suspect this approach might satisfy some of the people describing hold-ups in #68. I have been able to use this fork to bundle gray-matter with esbuild without error.

I would be comfortable publishing this with a patch-level version bump.