### PR TITLE
Update to js-yaml v4

### DIFF
--- a/lib/engines.js
+++ b/lib/engines.js
@@ -13,8 +13,8 @@ const engines = exports = module.exports;
  */
 
 engines.yaml = {
-  parse: yaml.safeLoad.bind(yaml),
-  stringify: yaml.safeDump.bind(yaml)
+  parse: yaml.load.bind(yaml),
+  stringify: yaml.dump.bind(yaml)
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "js-yaml": "^3.13.1",
+    "js-yaml": "^4.1.0",
     "kind-of": "^6.0.2",
     "section-matter": "^1.0.0",
     "strip-bom-string": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gray-matter",
   "description": "Parse front-matter from a string or file. Fast, reliable and easy to use. Parses YAML front matter by default, but also has support for YAML, JSON, TOML or Coffee Front-Matter, with options to set custom delimiters. Used by metalsmith, assemble, verb and many other projects.",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "homepage": "https://github.com/jonschlinkert/gray-matter",
   "author": "Jon Schlinkert (https://github.com/jonschlinkert)",
   "contributors": [


### PR DESCRIPTION
Updating to js-yaml 4.1.0 will dramatically reduce bundle size (~70%) and only requires replacing two function names.