### PR TITLE
Update esm import example

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Or with [typescript](https://www.typescriptlang.org)
 ```js
 import matter = require('gray-matter');
 // OR
-import * as matter from 'gray-matter';
+import matter from 'gray-matter';
 ```
 
 Pass a string and [options](#options) to gray-matter:


### PR DESCRIPTION
Using `import * as matter from 'gray-matter'` gets to top level scope of the module, not the default export. I'm guessing at some point the module was adjusted to have a default export, and this change updates the readme to support that.