### PR TITLE
feat: updating to use yaml

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "define-property": "^2.0.2",
-    "js-yaml": "^3.11.0",
+    "yaml": "^2.1.1",
     "kind-of": "^6.0.2",
     "section-matter": "^1.0.0",
     "strip-bom-string": "^1.0.0"

--- a/examples/sections.js
+++ b/examples/sections.js
@@ -2,14 +2,14 @@
 
 const fs = require('fs');
 const path = require('path');
-const yaml = require('js-yaml');
+const { parse } = require('yaml');
 const matter = require('..');
 const str = fs.readFileSync(path.join(__dirname, 'fixtures', 'sections.md'));
 
 const file = matter(str, {
   section: function(section, file) {
     if (typeof section.data === 'string' && section.data.trim() !== '') {
-      section.data = yaml.safeLoad(section.data);
+      section.data = parse(section.data);
     }
     section.content = section.content.trim() + '\n';
   }

--- a/index.js
+++ b/index.js
@@ -98,6 +98,11 @@ function parseMatter(file, options) {
   // get the raw front-matter block
   file.matter = str.slice(0, closeIndex);
 
+  // fix trailing '\r' on windows
+  if (file.matter.endsWith('\r')) {
+    file.matter = file.matter.slice(0, -1);
+  }
+
   const block = file.matter.replace(/^\s*#[^\n]+/gm, '').trim();
   if (block === '') {
     file.isEmpty = true;

--- a/lib/engines.js
+++ b/lib/engines.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const yaml = require('js-yaml');
+const { parse, stringify } = require('yaml');
 
 /**
  * Default engines
@@ -13,8 +13,8 @@ const engines = exports = module.exports;
  */
 
 engines.yaml = {
-  parse: yaml.safeLoad.bind(yaml),
-  stringify: yaml.safeDump.bind(yaml)
+  parse,
+  stringify
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
     "test": "mocha"
   },
   "dependencies": {
-    "js-yaml": "^3.13.1",
     "kind-of": "^6.0.2",
     "section-matter": "^1.0.0",
-    "strip-bom-string": "^1.0.0"
+    "strip-bom-string": "^1.0.0",
+    "yaml": "^2.1.1"
   },
   "devDependencies": {
     "ansi-green": "^0.1.1",

--- a/test/parse-custom.js
+++ b/test/parse-custom.js
@@ -8,7 +8,7 @@
 'use strict';
 
 var assert = require('assert');
-var YAML = require('js-yaml');
+var { parse } = require('yaml');
 var matter = require('..');
 
 describe('custom parser:', function() {
@@ -16,7 +16,7 @@ describe('custom parser:', function() {
     var actual = matter.read('./test/fixtures/lang-yaml.md', {
       parser: function customParser(str, opts) {
         try {
-          return YAML.safeLoad(str, opts);
+          return parse(str, opts);
         } catch (err) {
           throw new SyntaxError(err);
         }


### PR DESCRIPTION
use yaml instead of js-yaml
as requested in #145

@jonschlinkert are you sure `yaml` is smaller than `js-yaml` (for some reason bundlephobia is broken for yaml and vscode showing bigger package size, might be wrong due to shaking though)

`yaml` seems to behave slightly different as you can see in the two failing tests.