### PR TITLE
Remove deprecated safe prefix for js-yaml

### DIFF
--- a/examples/sections.js
+++ b/examples/sections.js
@@ -9,7 +9,7 @@ const str = fs.readFileSync(path.join(__dirname, 'fixtures', 'sections.md'));
 const file = matter(str, {
   section: function(section, file) {
     if (typeof section.data === 'string' && section.data.trim() !== '') {
-      section.data = yaml.safeLoad(section.data);
+      section.data = yaml.load(section.data);
     }
     section.content = section.content.trim() + '\n';
   }

--- a/lib/engines.js
+++ b/lib/engines.js
@@ -13,8 +13,8 @@ const engines = exports = module.exports;
  */
 
 engines.yaml = {
-  parse: yaml.safeLoad.bind(yaml),
-  stringify: yaml.safeDump.bind(yaml)
+  parse: yaml.load.bind(yaml),
+  stringify: yaml.dump.bind(yaml)
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "js-yaml": "^3.13.1",
+    "js-yaml": "^4.1.0",
     "kind-of": "^6.0.2",
     "section-matter": "^1.0.0",
     "strip-bom-string": "^1.0.0"

--- a/test/parse-custom.js
+++ b/test/parse-custom.js
@@ -16,7 +16,7 @@ describe('custom parser:', function() {
     var actual = matter.read('./test/fixtures/lang-yaml.md', {
       parser: function customParser(str, opts) {
         try {
-          return YAML.safeLoad(str, opts);
+          return YAML.load(str, opts);
         } catch (err) {
           throw new SyntaxError(err);
         }

--- a/test/parse-yaml.js
+++ b/test/parse-yaml.js
@@ -53,9 +53,9 @@ describe('parse YAML:', function() {
     assert(actual.hasOwnProperty('orig'));
   });
 
-  it('should use safeLoad when specified', function() {
+  it('should use safe by default', function() {
     var fixture = '---\nabc: xyz\nversion: 2\n---\n\n<span class="alert alert-info">This is an alert</span>\n';
-    var actual = matter(fixture, {safeLoad: true});
+    var actual = matter(fixture);
     assert.deepEqual(actual.data, {abc: 'xyz', version: 2});
     assert.equal(actual.content, '\n<span class="alert alert-info">This is an alert</span>\n');
     assert(actual.hasOwnProperty('orig'));


### PR DESCRIPTION
`js-yaml` have removed the `safeDump` and `safeLoad` (it's now safe by default).

This change prevents `Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.` from happening